### PR TITLE
Explicity include OpenCV header file `<opencv2/opencv.hpp>`

### DIFF
--- a/vpp/utils/opencv_bridge.hh
+++ b/vpp/utils/opencv_bridge.hh
@@ -1,6 +1,7 @@
 #ifndef VPP_OPENCV_BRIDGE_HH__
 # define VPP_OPENCV_BRIDGE_HH__
 
+# include <opencv2/opencv.hpp>
 # include <vpp/core/image2d.hh>
 
 namespace vpp


### PR DESCRIPTION
… without which, the luck of include-file ordering can otherwise make using this file problematically nondeterministic